### PR TITLE
Disable Groovy version check in Spock also in GroovyShell

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ repositories {
 
 test {
     useJUnitPlatform()
+    systemProperty("spock.iKnowWhatImDoing.disableGroovyVersionCheck", "true")  //for GroovyShell execution inside tests
 }
 
 tasks.withType(GroovyCompile).configureEach {


### PR DESCRIPTION
To prevent:
> IncompatibleGroovyVersionException: The Spock compiler plugin cannot execute because ...

in tests with GroovyShell. The difference is that GroovyShell triggers Spock AST transformation not during the test source code compilation, but during the tests execution (at - their - runtime), so the system property has to be provided also there.

P.S. It's good that I read your "Tales from the jar side" to know about your adventures :-).

P.P.S. Originally, I event had a section about that in a blog post - for a usage in embedded Spock test for Spock extensions, but in the end. I removed it to do not complete a post (testing Spock extensions with an incompatible Groovy version is a niche). However, you case seems to be somehow more often.